### PR TITLE
Update schemas to match assessments version 0.8.1

### DIFF
--- a/all-trials/color-dots.json
+++ b/all-trials/color-dots.json
@@ -1,6 +1,6 @@
 {
   "description": "All trials and metadata from the assessment Color Dots.",
-  "$comment": "Activity identifier: color-dots, version: 0.8.0. JSON Schema generated 2022-08-19T18:43:23.957Z.",
+  "$comment": "Activity identifier: color-dots, version: 0.8.1. JSON Schema generated 2022-10-03T12:34:50.031Z.",
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "type": "object",
   "required": [
@@ -19,6 +19,11 @@
     "trial": {
       "type": "object",
       "properties": {
+        "session_uuid": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Unique identifier for all activities in this administration of the session."
+        },
         "activity_uuid": {
           "type": "string",
           "format": "uuid",
@@ -234,6 +239,10 @@
                   "description": "Pixel depth of screen."
                 }
               }
+            },
+            "webGlRenderer": {
+              "type": "string",
+              "description": "WebGL driver vendor and renderer. Taken from WEBGL_debug_renderer_info."
             }
           }
         }

--- a/all-trials/grid-memory.json
+++ b/all-trials/grid-memory.json
@@ -1,6 +1,6 @@
 {
   "description": "All trials and metadata from the assessment Grid Memory.",
-  "$comment": "Activity identifier: grid-memory, version: 0.8.0. JSON Schema generated 2022-08-19T18:43:23.957Z.",
+  "$comment": "Activity identifier: grid-memory, version: 0.8.1. JSON Schema generated 2022-10-03T12:34:50.031Z.",
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "type": "object",
   "required": [
@@ -19,6 +19,11 @@
     "trial": {
       "type": "object",
       "properties": {
+        "session_uuid": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Unique identifier for all activities in this administration of the session."
+        },
         "activity_uuid": {
           "type": "string",
           "format": "uuid",
@@ -254,6 +259,10 @@
                   "description": "Pixel depth of screen."
                 }
               }
+            },
+            "webGlRenderer": {
+              "type": "string",
+              "description": "WebGL driver vendor and renderer. Taken from WEBGL_debug_renderer_info."
             }
           }
         }

--- a/all-trials/symbol-search.json
+++ b/all-trials/symbol-search.json
@@ -1,6 +1,6 @@
 {
   "description": "All trials and metadata from the assessment Symbol Search.",
-  "$comment": "Activity identifier: symbol-search, version: 0.8.0. JSON Schema generated 2022-08-19T18:43:23.957Z.",
+  "$comment": "Activity identifier: symbol-search, version: 0.8.1. JSON Schema generated 2022-10-03T12:34:50.031Z.",
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "type": "object",
   "required": [
@@ -19,6 +19,11 @@
     "trial": {
       "type": "object",
       "properties": {
+        "session_uuid": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Unique identifier for all activities in this administration of the session."
+        },
         "activity_uuid": {
           "type": "string",
           "format": "uuid",
@@ -187,6 +192,10 @@
                   "description": "Pixel depth of screen."
                 }
               }
+            },
+            "webGlRenderer": {
+              "type": "string",
+              "description": "WebGL driver vendor and renderer. Taken from WEBGL_debug_renderer_info."
             }
           }
         }

--- a/single-trial/color-dots.json
+++ b/single-trial/color-dots.json
@@ -1,9 +1,14 @@
 {
   "description": "A single trial and metadata from the assessment Color Dots.",
-  "$comment": "Activity identifier: color-dots, version: 0.8.0. JSON Schema generated 2022-08-19T18:43:23.957Z.",
+  "$comment": "Activity identifier: color-dots, version: 0.8.1. JSON Schema generated 2022-10-03T12:34:50.031Z.",
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "type": "object",
   "properties": {
+    "session_uuid": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for all activities in this administration of the session."
+    },
     "activity_uuid": {
       "type": "string",
       "format": "uuid",
@@ -219,6 +224,10 @@
               "description": "Pixel depth of screen."
             }
           }
+        },
+        "webGlRenderer": {
+          "type": "string",
+          "description": "WebGL driver vendor and renderer. Taken from WEBGL_debug_renderer_info."
         }
       }
     }

--- a/single-trial/grid-memory.json
+++ b/single-trial/grid-memory.json
@@ -1,9 +1,14 @@
 {
   "description": "A single trial and metadata from the assessment Grid Memory.",
-  "$comment": "Activity identifier: grid-memory, version: 0.8.0. JSON Schema generated 2022-08-19T18:43:23.957Z.",
+  "$comment": "Activity identifier: grid-memory, version: 0.8.1. JSON Schema generated 2022-10-03T12:34:50.031Z.",
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "type": "object",
   "properties": {
+    "session_uuid": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for all activities in this administration of the session."
+    },
     "activity_uuid": {
       "type": "string",
       "format": "uuid",
@@ -239,6 +244,10 @@
               "description": "Pixel depth of screen."
             }
           }
+        },
+        "webGlRenderer": {
+          "type": "string",
+          "description": "WebGL driver vendor and renderer. Taken from WEBGL_debug_renderer_info."
         }
       }
     }

--- a/single-trial/symbol-search.json
+++ b/single-trial/symbol-search.json
@@ -1,9 +1,14 @@
 {
   "description": "A single trial and metadata from the assessment Symbol Search.",
-  "$comment": "Activity identifier: symbol-search, version: 0.8.0. JSON Schema generated 2022-08-19T18:43:23.957Z.",
+  "$comment": "Activity identifier: symbol-search, version: 0.8.1. JSON Schema generated 2022-10-03T12:34:50.031Z.",
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "type": "object",
   "properties": {
+    "session_uuid": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for all activities in this administration of the session."
+    },
     "activity_uuid": {
       "type": "string",
       "format": "uuid",
@@ -172,6 +177,10 @@
               "description": "Pixel depth of screen."
             }
           }
+        },
+        "webGlRenderer": {
+          "type": "string",
+          "description": "WebGL driver vendor and renderer. Taken from WEBGL_debug_renderer_info."
         }
       }
     }


### PR DESCRIPTION
Regenerate the JSON schema so that it matches the output of the most recent version of the assessments.